### PR TITLE
fix: correct misleading docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Pathfinder enhances Neovim's native file navigation by extending `gf` (go to fil
 - **Enclosure Support**: Recognizes file paths in quotes, brackets, or custom, multi-character delimiters.
 - **Interactive Selection**: Choose from multiple matches with a simple prompt when ambiguity emerges.
 - **Flexible Opening Modes**: Open files in the current buffer, splits, tabs, or even external programs.
-- **Quick File Picker**: Use `select_files()` to jump to any visible file in the buffer, mapped to `<leader>gf` by default.
+- **Quick File Picker**: Use `select_file()` to jump to any visible file in the buffer, mapped to `<leader>gf` by default.
 
 ---
 
@@ -56,7 +56,7 @@ Pathfinder works out of the box by enhancing `gf` and `gF`. Here’s how it beha
 
 If multiple files match (e.g. `eval.c` and `eval.h`), Pathfinder prompts you to choose, unless configured to always select the first match.
 
-For a more visual workflow, you may use the `select_files()` function, mapped to `<leader>gf` by default, which is inspired by [EasyMotion](https://github.com/easymotion/vim-easymotion) and [Hop](https://github.com/hadronized/hop.nvim).
+For a more visual workflow, you may use the `select_file()` function, mapped to `<leader>gf` by default, which is inspired by [EasyMotion](https://github.com/easymotion/vim-easymotion) and [Hop](https://github.com/hadronized/hop.nvim).
 
 This displays all visible files in the buffer, letting you pick one with minimal keypresses.
 
@@ -91,7 +91,7 @@ require('pathfinder').setup({
 	-- User interaction
 	offer_multiple_options = true, -- If multiple valid files with the same name are found, prompt for action
 	remap_default_keys = true, -- Remap `gf`, `gF`, and `<leader>gf` to Pathfinder's functions
-	selection_keys = { "a", "s", "d", "f", "j", "k", "l" }, -- Keys to use for selection in `select_files()`
+	selection_keys = { "a", "s", "d", "f", "j", "k", "l" }, -- Keys to use for selection in `select_file()`
 })
 ```
 
@@ -122,7 +122,7 @@ require('pathfinder').setup({
   ```lua
     vim.keymap.set('n', 'gf', require('pathfinder').gf)
     vim.keymap.set('n', 'gF', require('pathfinder').gF)
-    vim.keymap.set('n', '<leader>gf', require('pathfinder').select_files)
+    vim.keymap.set('n', '<leader>gf', require('pathfinder').select_file)
   ```
 
 ---

--- a/doc/pathfinder.txt
+++ b/doc/pathfinder.txt
@@ -13,7 +13,7 @@ Configuration ...................................... |pathfinder-configuration|
     File Resolution .............................. |pathfinder-file-resolution|
     User Interaction ............................ |pathfinder-user-interaction|
 Functions .............................................. |pathfinder-functions|
-    select_files() .................................. |pathfinder-select-files|
+    select_file() .................................. |pathfinder-select-files|
 Filetype Overrides ............................ |pathfinder-filetype-overrides|
 Custom Key Mappings .............................. |pathfinder-custom-key-maps|
 
@@ -36,7 +36,7 @@ for navigating to files under the cursor. It enhances file resolution with:
 By default, this plugin remaps `gf` and `gF` to provide these enhancements,
 although this can be disabled and custom keymaps used.
 
-The function |pathfinder-select_files| is also provided, but unmapped by
+The function |pathfinder-select_file| is also provided, but unmapped by
 default. Inspired by other plugins, namely `EasyMotion`, it displays all file
 targets in the current visible area, allowing the user to open any in as few
 keystrokes as possible.
@@ -262,15 +262,15 @@ Default: `false` (boolean)
 selection_keys ~
 Default: `{ "a", "s", "d", "f", "j", "k", "l" }` (string[])
 
-    Keys used for user input when |select_files| is called. Useful for users
+    Keys used for user input when |select_file| is called. Useful for users
     of non-qwerty layouts.
 
 ==============================================================================
 							*pathfinder-functions*
 FUNCTIONS
 
-						     *pathfinder-select_files*
-select_files() ~
+						     *pathfinder-select_file*
+select_file() ~
 Inspired by plugins such as `EasyMotion` and `Hop`, this function displays all
 visible valid files in the current buffer and allows the user to select which
 one to open based on motion targets. This function is mapped to `<leader>gf`
@@ -304,6 +304,6 @@ setting your own key mappings. For example:
  })
  vim.keymap.set('n', 'gf', require('pathfinder').gf)
  vim.keymap.set('n', 'gF', require('pathfinder').gF)
- vim.keymap.set('n', '<leader>gf', require('pathfinder').select_files())
+ vim.keymap.set('n', '<leader>gf', require('pathfinder').select_file)
 <
 vim:tw=78:ts=8:noet:ft=help:norl:


### PR DESCRIPTION
Hey, awesome work on the plugin! This PR corrects references to the picker function, since in the code the function is defined as `select_file`, but the docs refer to it as `select_files`, which made me spend some time trying to understand what's going on and why I can't remap the picker function to a different key while using `remap_default_keys = false`. When I went in and checked the code, I immediately noticed what's wrong and I'd like to prevent people who are coming to try out the plugin using non-default keymaps from facing the same issue going forwards. Let me know if that sounds reasonable to you.

## Summary by Sourcery

Documentation:
- Corrects the name of the quick file picker function in the documentation from `select_files()` to `select_file()`.