### PR TITLE
Feat: <leader>gF to visually select file including the line number

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Pathfinder enhances Neovim's native file navigation by extending `gf` (go to fil
 - **Interactive Selection**: Choose from multiple matches with a simple prompt when ambiguity emerges.
 - **Flexible Opening Modes**: Open files in the current buffer, splits, tabs, or even external programs.
 - **Quick File Picker**: Use `select_file()` to jump to any visible file in the buffer, mapped to `<leader>gf` by default.
+- **Quick File Picker with line**: Use `select_file_line()` to jump to any visible file with line in the buffer, mapped to `<leader>gF` by default.
 
 ---
 
@@ -56,7 +57,7 @@ Pathfinder works out of the box by enhancing `gf` and `gF`. Here’s how it beha
 
 If multiple files match (e.g. `eval.c` and `eval.h`), Pathfinder prompts you to choose, unless configured to always select the first match.
 
-For a more visual workflow, you may use the `select_file()` function, mapped to `<leader>gf` by default, which is inspired by [EasyMotion](https://github.com/easymotion/vim-easymotion) and [Hop](https://github.com/hadronized/hop.nvim).
+For a more visual workflow, you may use the `select_file()` or `select_file_line` function, mapped to `<leader>gf` and `leader<gF>` by default, which is inspired by [EasyMotion](https://github.com/easymotion/vim-easymotion) and [Hop](https://github.com/hadronized/hop.nvim).
 
 This displays all visible files in the buffer, letting you pick one with minimal keypresses.
 
@@ -91,7 +92,7 @@ require('pathfinder').setup({
 	-- User interaction
 	offer_multiple_options = true, -- If multiple valid files with the same name are found, prompt for action
 	remap_default_keys = true, -- Remap `gf`, `gF`, and `<leader>gf` to Pathfinder's functions
-	selection_keys = { "a", "s", "d", "f", "j", "k", "l" }, -- Keys to use for selection in `select_file()`
+	selection_keys = { "a", "s", "d", "f", "j", "k", "l" }, -- Keys to use for selection in `select_file()` and `select_file_line()`
 })
 ```
 
@@ -133,6 +134,7 @@ vim.api.nvim_set_hl(0, "PathfinderFutureKeys", { fg = "#BB00AA", bg = "none" })
     vim.keymap.set('n', 'gf', require('pathfinder').gf)
     vim.keymap.set('n', 'gF', require('pathfinder').gF)
     vim.keymap.set('n', '<leader>gf', require('pathfinder').select_file)
+    vim.keymap.set('n', '<leader>gF', require('pathfinder').select_file_line)
   ```
 
 ---

--- a/doc/pathfinder.txt
+++ b/doc/pathfinder.txt
@@ -124,7 +124,7 @@ Defaults ~
 						 *pathfinder-highlight-groups*
 Highlight Groups ~
 
-The |select_file| function uses the following default highlight groups, which
+The |select_file| and |select_file_line| functions use the following default highlight groups, which
 may be overridden:
 
 >lua
@@ -304,6 +304,21 @@ See |pathfinder-highlight-groups|.
 Note that |offer_multiple_options| isn't currently implemented with this
 function.
 
+
+						     *pathfinder-select_file_line*
+select_file_line() ~
+Inspired by plugins such as `EasyMotion` and `Hop`, this function displays all
+visible valid files in the current buffer and allows the user to select which
+one to open on line based on motion targets. 
+This function is mapped to `<leader>gF` by default.
+
+The colour scheme used by this function is configurable via highlight groups.
+See |pathfinder-highlight-groups|.
+
+Note that |offer_multiple_options| isn't currently implemented with this
+function.
+
+
 ==============================================================================
 					       *pathfinder-filetype-overrides*
 FILETYPE OVERRIDES
@@ -330,5 +345,6 @@ setting your own key mappings. For example:
  vim.keymap.set('n', 'gf', require('pathfinder').gf)
  vim.keymap.set('n', 'gF', require('pathfinder').gF)
  vim.keymap.set('n', '<leader>gf', require('pathfinder').select_file)
+ vim.keymap.set('n', '<leader>gF', require('pathfinder').select_file_line)
 <
 vim:tw=78:ts=8:noet:ft=help:norl:

--- a/lua/pathfinder/highlight.lua
+++ b/lua/pathfinder/highlight.lua
@@ -13,7 +13,7 @@ local function set_default_highlight(group, default)
 	end
 end
 
-function M.select_file()
+local function select_file(is_gF)
 	local candidate_highlight_group = "PathfinderHighlight"
 	local dim_group = "PathfinderDim"
 	local next_key_group = "PathfinderNextKey"
@@ -222,7 +222,8 @@ function M.select_file()
 					vim.api.nvim_buf_clear_namespace(current_buffer, dim_ns, 0, -1)
 					vim.cmd("redraw")
 					vim.schedule(function()
-						core.try_open_file(matching_candidates[1], false, 1)
+            local linenr = matching_candidates[1].candidate_info.linenr
+            core.try_open_file(matching_candidates[1], is_gF, linenr or 1)
 					end)
 					break
 				elseif #user_input < required_length then
@@ -258,5 +259,14 @@ function M.select_file()
 	cand_list = candidates.deduplicate_candidates(cand_list)
 	validate_candidates(1, cand_list)
 end
+
+function M.select_file_line()
+  select_file(true)
+end
+
+function M.select_file()
+  select_file(false)
+end
+
 
 return M

--- a/lua/pathfinder/init.lua
+++ b/lua/pathfinder/init.lua
@@ -68,6 +68,7 @@ if ensure_neovim_version() then
 	M.gf = core.gf
 	M.gF = core.gF
 	M.select_file = highlight.select_file
+	M.select_file_line = highlight.select_file_line
 
 	local function setup_autocommands()
 		vim.api.nvim_create_autocmd({ "FileType", "BufEnter", "VimEnter" }, {
@@ -81,6 +82,7 @@ if ensure_neovim_version() then
 			vim.keymap.set("n", "gf", M.gf, { silent = true, desc = "Enhanced go to file" })
 			vim.keymap.set("n", "gF", M.gF, { silent = true, desc = "Enhanced go to file (line)" })
 			vim.keymap.set("n", "<leader>gf", M.select_file, { silent = true, desc = "Visual file selection" })
+			vim.keymap.set("n", "<leader>gF", M.select_file_line, { silent = true, desc = "Visual file selection (line)" })
 		end
 	end
 
@@ -93,6 +95,7 @@ else
 	M.gf = noop
 	M.gF = noop
 	M.select_file = noop
+	M.select_file_line = noop
 end
 
 return M


### PR DESCRIPTION
Hi,

Im the guy from reddit that really likes the terminal functionality of this plugin.
Since you added support for terminal already I patched the last easy thing myself.

I've went with adding is_gF to a `local select_file(is_gF)` function since there is really only one line that needs change as far as I can see.
Now includes `M.select_file()` and `M.select_file_line()` and introduced a new mapping `<leader>gF` for visual file with line jumping.

That's how I patched it for me, feel free to use it if you think its good. I went ahead and updated the docs as well for the new mappings.

Thanks for this cool plugin!

## Summary by Sourcery

Add support for visually selecting a file with line number using a new mapping

New Features:
- Introduce a new mapping <leader>gF to visually select a file and jump to a specific line number

Enhancements:
- Refactor select_file function to support optional line number selection
- Add a new select_file_line() function to enable line-specific file selection

Documentation:
- Update README and documentation to describe the new <leader>gF mapping and file selection with line functionality