### PR TITLE
fix: correct documentation for select_file_line() and select_file()

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Pathfinder works out of the box by enhancing `gf` and `gF`. Here’s how it beha
 
 If multiple files match (e.g. `eval.c` and `eval.h`), Pathfinder prompts you to choose, unless configured to always select the first match.
 
-For a more visual workflow, you may use the `select_file()` or `select_file_line` function, mapped to `<leader>gf` and `leader<gF>` by default, which is inspired by [EasyMotion](https://github.com/easymotion/vim-easymotion) and [Hop](https://github.com/hadronized/hop.nvim).
+For a more visual workflow, you may use the `select_file()` or `select_file_line()` function, mapped to `<leader>gf` and `leader<gF>` by default, which is inspired by [EasyMotion](https://github.com/easymotion/vim-easymotion) and [Hop](https://github.com/hadronized/hop.nvim).
 
 This displays all visible files in the buffer, letting you pick one with minimal keypresses.
 

--- a/doc/pathfinder.txt
+++ b/doc/pathfinder.txt
@@ -13,7 +13,8 @@ Configuration ...................................... |pathfinder-configuration|
     File Resolution .............................. |pathfinder-file-resolution|
     User Interaction ............................ |pathfinder-user-interaction|
 Functions .............................................. |pathfinder-functions|
-    select_file() .................................. |pathfinder-select-files|
+    select_file() .................................. |pathfinder-select_file|
+    select_file_line() ........................ |pathfinder-select_file_line|
 Filetype Overrides ............................ |pathfinder-filetype-overrides|
 Custom Key Mappings .............................. |pathfinder-custom-key-maps|
 


### PR DESCRIPTION
Hi, 

Thanks for merging the <leader>gF functionality.
Just noticed that I kinda didn't do the vimdoc table of contents correctly and had a typo inside readme.md.

## Summary by Sourcery

Documentation:
- Fixed a typo in the README.md documentation for select_file() and select_file_line() functions, ensuring correct function name representation