### PR TITLE
Fix: properly support file:// prefix

### DIFF
--- a/lua/pathfinder/candidates.lua
+++ b/lua/pathfinder/candidates.lua
@@ -508,7 +508,6 @@ function M.scan_line(
 				local abs_finish_col = match_e
 				if not min_col or abs_finish_col >= min_col then
 					if filename and filename ~= "" and linenr_str then
-						filename = vim.uri_to_fname(filename)
 						local candidate = {
 							filename = normalize_filename(filename),
 							lnum = lnum,

--- a/lua/pathfinder/candidates.lua
+++ b/lua/pathfinder/candidates.lua
@@ -372,7 +372,6 @@ local function parse_words_in_segment(
 			local abs_finish_col = start_pos + match_e - 1
 			if not min_col or abs_finish_col >= min_col then
 				if filename and filename ~= "" and linenr_str then
-					filename = vim.uri_to_fname(filename)
 					local matched_text = segment:sub(match_s, match_e)
 					local match_item = {
 						filename = normalize_filename(filename),

--- a/lua/pathfinder/candidates.lua
+++ b/lua/pathfinder/candidates.lua
@@ -15,6 +15,15 @@ local trailing_patterns = {
 	{ pattern = "^,?%s*line%s+(%d+)" }, -- e.g. ", line 168"
 }
 
+-- If URI, convert to normal file path.
+local function normalize_filename(fname)
+	local ok, local_path = pcall(vim.uri_to_fname, fname)
+	if ok then
+		return local_path
+	end
+	return fname
+end
+
 function M.deduplicate_candidates(candidates)
 	local merged = {}
 	for _, cand in ipairs(candidates) do
@@ -98,7 +107,7 @@ function M.parse_filename_and_linenr(str)
 		local filename, linenr_str = str:match(pat.pattern)
 		if filename and linenr_str then
 			filename = vim.trim(filename)
-			filename = vim.uri_to_fname(filename):gsub("[.,:;!]+$", "")
+			filename = filename:gsub("[.,:;!]+$", "")
 			return filename, tonumber(linenr_str)
 		end
 	end
@@ -198,7 +207,7 @@ local function create_candidate_from_piece(
 		local filename, linenr = M.parse_filename_and_linenr(filename_str)
 		if filename and filename ~= "" then
 			local candidate = {
-				filename = filename,
+				filename = normalize_filename(filename),
 				lnum = lnum,
 				start_col = cand_start_col,
 				finish = cand_finish_col,
@@ -366,7 +375,7 @@ local function parse_words_in_segment(
 					filename = vim.uri_to_fname(filename)
 					local matched_text = segment:sub(match_s, match_e)
 					local match_item = {
-						filename = filename,
+						filename = normalize_filename(filename),
 						lnum = lnum,
 						start_col = abs_start_col,
 						finish = abs_finish_col,
@@ -502,7 +511,7 @@ function M.scan_line(
 					if filename and filename ~= "" and linenr_str then
 						filename = vim.uri_to_fname(filename)
 						local candidate = {
-							filename = filename,
+							filename = normalize_filename(filename),
 							lnum = lnum,
 							start_col = abs_start_col,
 							finish = abs_finish_col,

--- a/lua/pathfinder/candidates.lua
+++ b/lua/pathfinder/candidates.lua
@@ -98,7 +98,7 @@ function M.parse_filename_and_linenr(str)
 		local filename, linenr_str = str:match(pat.pattern)
 		if filename and linenr_str then
 			filename = vim.trim(filename)
-			filename = filename:gsub("[.,:;!]+$", "")
+			filename = vim.uri_to_fname(filename):gsub("[.,:;!]+$", "")
 			return filename, tonumber(linenr_str)
 		end
 	end
@@ -363,6 +363,7 @@ local function parse_words_in_segment(
 			local abs_finish_col = start_pos + match_e - 1
 			if not min_col or abs_finish_col >= min_col then
 				if filename and filename ~= "" and linenr_str then
+					filename = vim.uri_to_fname(filename)
 					local matched_text = segment:sub(match_s, match_e)
 					local match_item = {
 						filename = filename,
@@ -499,6 +500,7 @@ function M.scan_line(
 				local abs_finish_col = match_e
 				if not min_col or abs_finish_col >= min_col then
 					if filename and filename ~= "" and linenr_str then
+						filename = vim.uri_to_fname(filename)
 						local candidate = {
 							filename = filename,
 							lnum = lnum,


### PR DESCRIPTION
Attempting a `gF` on a file prefixed with `file://` would result in valid file targets being found. This PR simply adds a `gsub("^file://", "")` on filenames. I don't have a good enough familiarity with this repo to know if we should also update offsets anywhere (i.e. `match_s`) but it fixed gF behavior for me.

This is a longstanding issue on vim-fetch: https://github.com/wsdjeg/vim-fetch/issues/40 so would be nice to have an alternative with a fix for neovim.

## Summary by Sourcery

Strip the file:// prefix from filenames when parsing candidates to fix gF lookup on file URI paths

Bug Fixes:
- Remove leading file:// from filenames in parse_filename_and_linenr to enable proper file target detection
- Strip file:// prefix in parse_words_in_segment to support file URI scanning
- Strip file:// prefix in scan_line to ensure gF works with file URI paths